### PR TITLE
cargo clippy and rustfmt

### DIFF
--- a/src/arclenparameterization.rs
+++ b/src/arclenparameterization.rs
@@ -1,69 +1,65 @@
-use crate::coordinate::Coordinate as _;
 use super::evaluate::Evaluate;
 use super::parameterization::Parameterization;
+use crate::coordinate::Coordinate as _;
 
 // We build a table of total arc length along the line and use it to map 0-1
 // to the arclength of the curve such that 0.5 is halfway along the curve by arc-length
 #[derive(Debug, Clone)]
-pub struct ArcLengthParameterization
-{
-    pub arclens: Vec<f64>
+pub struct ArcLengthParameterization {
+    pub arclens: Vec<f64>,
 }
 
-impl ArcLengthParameterization
-{
+impl ArcLengthParameterization {
     /// An evaluable and an accuracy value which defines how many lines we use to measure length.
-    pub fn from<T: Evaluate>(evaluable: &T, accuracy: i32) -> Self
-    {
+    pub fn from<T: Evaluate>(evaluable: &T, accuracy: i32) -> Self {
         let mut output = Vec::new();
 
         let mut prev_point = evaluable.at(0.0);
         let mut sum = 0.0;
         output.push(sum);
-        
+
         let mut i = 1;
-        while i < accuracy + 1
-        {
+        while i < accuracy + 1 {
             let t = i as f64 / accuracy as f64;
             let point = evaluable.at(t);
             let dist = point.distance(prev_point);
-            sum = sum + dist;
+            sum += dist;
             output.push(sum);
 
             prev_point = point;
-            i = i + 1;
+            i += 1;
         }
 
-        return Self {
-            arclens: output
-        }
+        Self { arclens: output }
     }
 
-    pub fn get_total_arclen(&self) -> f64
-    {
+    pub fn get_total_arclen(&self) -> f64 {
         return *self.arclens.last().unwrap();
     }
 
     // Have to implement a custom binary search here because we're looking
     // not for an exact index but the index of the highest value that's less than
     // the target
-    fn search_for_index(&self, target: f64) -> usize
-    {
+    fn search_for_index(&self, target: f64) -> usize {
         let mut left = 0;
         let mut right = self.arclens.len() - 1;
 
         while left < right {
-            let middle = (right+left)/2;
+            let middle = (right + left) / 2;
 
-            if left == middle { return middle; }
-            if right == middle { return left; }
-            if self.arclens[middle] == target { return middle };
+            if left == middle {
+                return middle;
+            }
+            if right == middle {
+                return left;
+            }
+            if self.arclens[middle] == target {
+                return middle;
+            };
 
             if self.arclens[middle] < target {
                 left = middle
-            }
-            else
-            {
+            } else {
                 right = middle;
             }
         }
@@ -73,38 +69,37 @@ impl ArcLengthParameterization
     }
 
     pub fn get_arclen_from_t(&self, t: f64) -> f64 {
-        let fractional_index = t * (self.arclens.len()-1) as f64;
+        let fractional_index = t * (self.arclens.len() - 1) as f64;
         let index = fractional_index as usize;
         let fraction = fractional_index - index as f64;
 
         let len_start = self.arclens[index];
-        let len_end = if index != self.arclens.len() - 1 {self.arclens[index+1]} else {1.};
+        let len_end = if index != self.arclens.len() - 1 {
+            self.arclens[index + 1]
+        } else {
+            1.
+        };
         let segment_len = len_start - len_end;
 
-        return len_start + segment_len * fraction;
+        len_start + segment_len * fraction
     }
 }
 
-impl Parameterization for ArcLengthParameterization
-{
-    fn parameterize(&self, u: f64) -> f64
-    {
+impl Parameterization for ArcLengthParameterization {
+    fn parameterize(&self, u: f64) -> f64 {
         let target_arclen = u * self.arclens[self.arclens.len() - 1];
- 
+
         let arclen_index = self.search_for_index(target_arclen);
-        if target_arclen == self.arclens[arclen_index]
-        {
-           return arclen_index as f64 / (self.arclens.len() - 1) as f64;
-        }
-        else
-        {
+        if target_arclen == self.arclens[arclen_index] {
+            arclen_index as f64 / (self.arclens.len() - 1) as f64
+        } else {
             let len_start = self.arclens[arclen_index];
-            let len_end = self.arclens[arclen_index+1];
+            let len_end = self.arclens[arclen_index + 1];
             let segment_len = len_end - len_start;
 
             let segment_fraction = (target_arclen - len_start) / segment_len;
 
-            return (arclen_index as f64 + segment_fraction) / (self.arclens.len() - 1) as f64;
+            (arclen_index as f64 + segment_fraction) / (self.arclens.len() - 1) as f64
         }
     }
 }

--- a/src/bezier/evaluate.rs
+++ b/src/bezier/evaluate.rs
@@ -1,14 +1,13 @@
-use super::super::{Vector, Evaluate, Rect, Bezier};
+use super::super::{Bezier, Evaluate, Rect, Vector};
 
 use flo_curves::BezierCurve;
 
-use flo_curves::bezier::{derivative4, de_casteljau3, de_casteljau4};
+use flo_curves::bezier::{de_casteljau3, de_casteljau4, derivative4};
 
 impl Evaluate for Bezier {
     type EvalResult = Vector;
-    
-    fn at(&self, t: f64) -> Vector
-    {
+
+    fn at(&self, t: f64) -> Vector {
         let d1 = BezierCurve::start_point(self);
         let (d2, d3) = BezierCurve::control_points(self);
         let d4 = BezierCurve::end_point(self);
@@ -16,29 +15,28 @@ impl Evaluate for Bezier {
         de_casteljau4(t, d1, d2, d3, d4)
     }
 
-    
-    fn tangent_at(&self, t: f64) -> Vector
-    {
-            // Extract the points that make up this curve
-            let w1          = BezierCurve::start_point(self);
-            let (w2, w3)    = BezierCurve::control_points(self);
-            let w4          = BezierCurve::end_point(self);
-    
-            // If w1 == w2 or w3 == w4 there will be an anomaly at t=0.0 and t=1.0 
-            // (it's probably mathematically correct to say there's no tangent at these points but the result is surprising and probably useless in a practical sense)
-            let t = if t == 0.0 { f64::EPSILON }        else { t };
-            let t = if t == 1.0 { 1.0-f64::EPSILON }    else { t };
-    
-            // Get the deriviative
-            let (d1, d2, d3) = derivative4(w1, w2, w3, w4);
-    
-            // Get the tangent and the point at the specified t value
-            let tangent     = de_casteljau3(t, d1, d2, d3);
-    
-            tangent
+    fn tangent_at(&self, t: f64) -> Vector {
+        // Extract the points that make up this curve
+        let w1 = BezierCurve::start_point(self);
+        let (w2, w3) = BezierCurve::control_points(self);
+        let w4 = BezierCurve::end_point(self);
+
+        // If w1 == w2 or w3 == w4 there will be an anomaly at t=0.0 and t=1.0
+        // (it's probably mathematically correct to say there's no tangent at these points but the result is surprising and probably useless in a practical sense)
+        let t = if t == 0.0 { f64::EPSILON } else { t };
+        let t = if t == 1.0 { 1.0 - f64::EPSILON } else { t };
+
+        // Get the deriviative
+        let (d1, d2, d3) = derivative4(w1, w2, w3, w4);
+
+        // Get the tangent and the point at the specified t value
+
+        de_casteljau3(t, d1, d2, d3)
     }
 
-    fn apply_transform<F>(&self, transform: F) -> Self where F: Fn(&Vector) -> Vector
+    fn apply_transform<F>(&self, transform: F) -> Self
+    where
+        F: Fn(&Vector) -> Vector,
     {
         let original_points = self.to_control_points();
         let tp: [Vector; 4] = [
@@ -48,23 +46,18 @@ impl Evaluate for Bezier {
             transform(&original_points[3]),
         ];
 
-        return Bezier::from_points(tp[0], tp[1], tp[2], tp[3]);
+        Bezier::from_points(tp[0], tp[1], tp[2], tp[3])
     }
 
-    fn bounds(&self) -> Rect
-    {
-        return Rect::AABB_from_points(self.to_control_points_vec());
+    fn bounds(&self) -> Rect {
+        Rect::AABB_from_points(self.to_control_points_vec())
     }
 
-    fn start_point(&self) -> Vector
-    {
-        return self.to_control_points()[0];
-
+    fn start_point(&self) -> Vector {
+        self.to_control_points()[0]
     }
 
-    fn end_point(&self) -> Vector
-    {
-        return self.to_control_points()[3];
+    fn end_point(&self) -> Vector {
+        self.to_control_points()[3]
     }
-
 }

--- a/src/bezier/flo.rs
+++ b/src/bezier/flo.rs
@@ -1,9 +1,11 @@
 use super::super::Vector;
 use crate::Piecewise;
 
-use flo_curves::bezier::{BezierCurve, BezierCurveFactory, path::{BezierPath, BezierPathFactory}};
+use flo_curves::bezier::{
+    path::{BezierPath, BezierPathFactory},
+    BezierCurve, BezierCurveFactory,
+};
 use flo_curves::geo::Geo;
-
 
 use super::Bezier;
 
@@ -12,25 +14,25 @@ impl Geo for Bezier {
 }
 
 impl BezierCurveFactory for Bezier {
-    fn from_points(start: Vector, (control_point1, control_point2): (Vector, Vector), end: Vector) -> Self {
-        let bez = Bezier::from_points(start, control_point1, control_point2, end);
-        return bez;
+    fn from_points(
+        start: Vector,
+        (control_point1, control_point2): (Vector, Vector),
+        end: Vector,
+    ) -> Self {
+        Bezier::from_points(start, control_point1, control_point2, end)
     }
 }
 
 impl BezierCurve for Bezier {
-    fn start_point(&self) -> Self::Point
-    {
+    fn start_point(&self) -> Self::Point {
         self.to_control_points()[0]
     }
 
-    fn end_point(&self) -> Self::Point
-    {
+    fn end_point(&self) -> Self::Point {
         self.to_control_points()[3]
     }
 
-    fn control_points(&self) -> (Self::Point, Self::Point)
-    {
+    fn control_points(&self) -> (Self::Point, Self::Point) {
         let cp = self.to_control_points();
         (cp[1], cp[2])
     }
@@ -48,12 +50,25 @@ impl BezierPath for Piecewise<Bezier> {
     }
 
     fn points(&self) -> Self::PointIter {
-        self.segs.iter().map(|s|(s.to_control_points()[1], s.to_control_points()[2], s.to_control_points()[3])).collect::<Vec<_>>().into_iter()
+        self.segs
+            .iter()
+            .map(|s| {
+                (
+                    s.to_control_points()[1],
+                    s.to_control_points()[2],
+                    s.to_control_points()[3],
+                )
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 
 impl BezierPathFactory for Piecewise<Bezier> {
-    fn from_points<FromIter: IntoIterator<Item=(Self::Point, Self::Point, Self::Point)>>(mut start_point: Self::Point, points: FromIter) -> Self {
+    fn from_points<FromIter: IntoIterator<Item = (Self::Point, Self::Point, Self::Point)>>(
+        mut start_point: Self::Point,
+        points: FromIter,
+    ) -> Self {
         let mut vb: Vec<Bezier> = vec![];
         for p in points.into_iter() {
             vb.push(Bezier::from_points(start_point, p.0, p.1, p.2));

--- a/src/bezier/mod.rs
+++ b/src/bezier/mod.rs
@@ -21,16 +21,16 @@ impl Bezier {
         let h1 = Vector::from_handle(point, WhichHandle::A);
         let h2 = Vector::from_handle(next_point, WhichHandle::B);
 
-        return Self::from_points(p, h1, h2, np);
+        Self::from_points(p, h1, h2, np)
     }
 
     pub fn from_points(p0: Vector, p1: Vector, p2: Vector, p3: Vector) -> Self {
-        return Bezier {
+        Bezier {
             w1: p0,
             w2: p1,
             w3: p2,
             w4: p3,
-        };
+        }
     }
 
     pub fn to_control_points(&self) -> [Vector; 4] {
@@ -42,10 +42,10 @@ impl Bezier {
 
         let mut output = Vec::new();
         for p in &controlps {
-            output.push(p.clone());
+            output.push(*p);
         }
 
-        return output;
+        output
     }
 
     pub fn reverse(&self) -> Self {

--- a/src/coordinate.rs
+++ b/src/coordinate.rs
@@ -1,7 +1,14 @@
 use std::cmp::PartialEq;
 use std::ops::{Add, Mul, Sub};
 
-pub trait Coordinate : Sized+Copy+Add<Self, Output=Self>+Mul<Self, Output=Self>+Sub<Self, Output=Self>+PartialEq {
+pub trait Coordinate:
+    Sized
+    + Copy
+    + Add<Self, Output = Self>
+    + Mul<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + PartialEq
+{
     fn magnitude(self) -> f64;
     fn distance(self, v1: Self) -> f64;
     fn lerp(self, v1: Self, t: f64) -> Self;
@@ -15,14 +22,14 @@ pub trait Coordinate2D: Coordinate {
 
 impl Coordinate for f64 {
     fn magnitude(self) -> Self {
-        return f64::abs(self);
+        f64::abs(self)
     }
 
     fn distance(self, v1: Self) -> Self {
-        return f64::abs(self - v1);
+        f64::abs(self - v1)
     }
 
     fn lerp(self, v1: Self, t: f64) -> Self {
-        return (1. - t) * self + t * v1;
+        (1. - t) * self + t * v1
     }
 }

--- a/src/dash_along_path/mod.rs
+++ b/src/dash_along_path/mod.rs
@@ -1,12 +1,15 @@
-use glifparser::PointData;
 use glifparser::glif::{DashContour, Glif};
+use glifparser::outline::skia::{
+    ConicsToCubics as _, FromSkOutline as _, FromSkiaPath as _, SplitSkiaPath as _,
+    ToSkiaPath as _, ToSkiaPaths as _,
+};
 use glifparser::outline::Outline;
-use glifparser::outline::skia::{FromSkiaPath as _, ToSkiaPath as _, ToSkiaPaths as _, SplitSkiaPath as _, ConicsToCubics as _, FromSkOutline as _};
 use glifparser::point::PointType;
-use kurbo::{Point as KurboPoint, BezPath as KurboPath, PathEl as KurboEl};
+use glifparser::PointData;
 use kurbo::Shape as _;
-use skia_safe as skia;
+use kurbo::{BezPath as KurboPath, PathEl as KurboEl, Point as KurboPoint};
 use skia::{PathEffect, StrokeRec};
+use skia_safe as skia;
 
 use log;
 
@@ -19,8 +22,18 @@ fn add_flutter_to_dash_description(desc: &mut Vec<f32>, slen: f32) -> f32 {
     let w = if m.is_nan() { 0. } else { dash_len * m };
     let desc_len = desc.len() as f32;
     let w_d = (w / s_d / desc_len) as f32;
-    desc.iter_mut().for_each(|f|{ *f+=w_d; });
-    log::trace!("slen {}, gap_len {} → s/g {} → m {} → w {}, w_d {}", slen, gap_len, s_g, m, w, w_d);
+    desc.iter_mut().for_each(|f| {
+        *f += w_d;
+    });
+    log::trace!(
+        "slen {}, gap_len {} → s/g {} → m {} → w {}, w_d {}",
+        slen,
+        gap_len,
+        s_g,
+        m,
+        w,
+        w_d
+    );
     w_d
 }
 
@@ -30,13 +43,18 @@ fn path_effect_with_flutter(slen: f32, settings: &DashContour) -> PathEffect {
     let w_d = add_flutter_to_dash_description(&mut desc, slen);
     let flutter = w_d * desc.iter().skip(1).step_by(2).len() as f32;
     if flutter > 1.0 {
-        log::warn!("Added a lot of flutter ({}) to dashes ({} over {} segments)", flutter, w_d, desc.len());
+        log::warn!(
+            "Added a lot of flutter ({}) to dashes ({} over {} segments)",
+            flutter,
+            w_d,
+            desc.len()
+        );
     }
     PathEffect::dash(&desc, 0.).unwrap()
 }
 
 fn make_dash_effect(skp: &skia::Path, settings: &DashContour) -> Vec<PathEffect> {
-    let mut measure = skia::PathMeasure::from_path(&skp, false, None);
+    let mut measure = skia::PathMeasure::from_path(skp, false, None);
     let mut slens = vec![measure.length()];
     while measure.next_contour() {
         slens.push(measure.length());
@@ -50,12 +68,15 @@ fn make_dash_effect(skp: &skia::Path, settings: &DashContour) -> Vec<PathEffect>
 
 use std::mem;
 
-pub fn dash_along_path<PD: PointData>(outline: &Outline<PD>, settings: &DashContour) -> Outline<PD> {
+pub fn dash_along_path<PD: PointData>(
+    outline: &Outline<PD>,
+    settings: &DashContour,
+) -> Outline<PD> {
     let skp = outline.to_skia_paths(None).combined();
-    let path_effects = make_dash_effect(&skp, &settings);
+    let path_effects = make_dash_effect(&skp, settings);
 
     let mut paint = skia::Paint::default();
-    use skia::{PaintJoin, PaintCap};
+    use skia::{PaintCap, PaintJoin};
     paint.set_style(skia::PaintStyle::Stroke);
     paint.set_stroke_width(settings.stroke_width);
     unsafe {
@@ -70,13 +91,18 @@ pub fn dash_along_path<PD: PointData>(outline: &Outline<PD>, settings: &DashCont
         cull_paint.set_stroke_width(cull.width);
         s_r_c = StrokeRec::from_paint(&cull_paint, skia::PaintStyle::Stroke, 10.);
     }
-    let mut gpskp: Outline::<()> = Outline::from_skia_path(&skp);
+    let mut gpskp: Outline<()> = Outline::from_skia_path(&skp);
     let mut skp_o = skia::Path::new();
     for (i, gpath) in gpskp.iter_mut().enumerate() {
         let mut gpath_o = skia::Path::new();
         let mut s_r = StrokeRec::from_paint(&paint, skia::PaintStyle::Stroke, 10.);
         let path = gpath.to_skia_path(None).unwrap();
-        path_effects[i].filter_path_inplace(&mut gpath_o, &path, &mut s_r, skia::Rect::new(0., 0., 0., 0.));
+        path_effects[i].filter_path_inplace(
+            &mut gpath_o,
+            &path,
+            &mut s_r,
+            skia::Rect::new(0., 0., 0., 0.),
+        );
         if gpath_o.count_points() == 0 || gpath_o.is_empty() {
             s_r = StrokeRec::from_paint(&paint, skia::PaintStyle::Stroke, 10.);
             s_r.apply_to_path(&mut gpath_o, &path);
@@ -85,7 +111,7 @@ pub fn dash_along_path<PD: PointData>(outline: &Outline<PD>, settings: &DashCont
     }
     let mut final_skpath = skia::Path::new();
 
-    let gpskp_o: Outline::<()> = Outline::from_skia_path(&skp_o);
+    let gpskp_o: Outline<()> = Outline::from_skia_path(&skp_o);
     for (i, gpath) in gpskp_o.iter().enumerate() {
         let path = gpath.to_skia_path(None).unwrap();
         if i == gpskp_o.len() - 1 && !settings.include_last_path && settings.cull.is_some() {
@@ -109,7 +135,9 @@ pub fn dash_along_path<PD: PointData>(outline: &Outline<PD>, settings: &DashCont
 
         if settings.stroke_width != 0.0 && settings.cull.is_some() {
             match final_skpath.op(&skp_o_s, skia::PathOp::Union) {
-                Some(fsk) => { final_skpath = fsk; }
+                Some(fsk) => {
+                    final_skpath = fsk;
+                }
                 None => {
                     log::error!("Ran into a skia::PathOp::Union that refused to resolve. This is likely a Skia bug; downgrading to overlapping splines. (Consider testing w/MFEKpathops BOOLEAN)");
                     final_skpath.add_path(&skp_o_s, (0., 0.), None);
@@ -127,24 +155,39 @@ pub fn dash_along_path<PD: PointData>(outline: &Outline<PD>, settings: &DashCont
     for skc in skoutline {
         let mut kurbo_vec = vec![];
         for (pointtype, points, _) in skc.iter() {
-            let kurbo_points: Vec<KurboPoint> = points.iter().map(|p|KurboPoint::new(p.x as f64, p.y as f64)).collect();
+            let kurbo_points: Vec<KurboPoint> = points
+                .iter()
+                .map(|p| KurboPoint::new(p.x as f64, p.y as f64))
+                .collect();
             match pointtype {
                 PointType::Move => kurbo_vec.push(KurboEl::MoveTo(kurbo_points[0])),
                 PointType::Line => kurbo_vec.push(KurboEl::LineTo(kurbo_points[0])),
-                PointType::Curve => kurbo_vec.push(KurboEl::CurveTo(kurbo_points[0], kurbo_points[1], kurbo_points[2])),
-                _ => ()
+                PointType::Curve => kurbo_vec.push(KurboEl::CurveTo(
+                    kurbo_points[0],
+                    kurbo_points[1],
+                    kurbo_points[2],
+                )),
+                _ => (),
             }
         }
         if settings.stroke_width != 0.0 {
             kurbo_vec.push(KurboEl::ClosePath);
         }
         let kpath = KurboPath::from_vec(kurbo_vec);
-        let area = if settings.stroke_width != 0.0 { kpath.area() } else { kpath.perimeter(1.) };
-        if area.abs() > settings.cull.map(|c|c.area_cutoff as f64).unwrap_or(0.) {
+        let area = if settings.stroke_width != 0.0 {
+            kpath.area()
+        } else {
+            kpath.perimeter(1.)
+        };
+        if area.abs() > settings.cull.map(|c| c.area_cutoff as f64).unwrap_or(0.) {
             // uses glifparser trait FromSkOutline
             let mut ol = Outline::from_skoutline(vec![skc]);
             if settings.stroke_width == 0.0 {
-                ol.first_mut().map(|c|c.first_mut().map(|p|{p.ptype = PointType::Move;}));
+                ol.first_mut().map(|c| {
+                    c.first_mut().map(|p| {
+                        p.ptype = PointType::Move;
+                    })
+                });
             }
             final_output.extend(ol);
         }
@@ -156,9 +199,9 @@ pub fn dash_along_path<PD: PointData>(outline: &Outline<PD>, settings: &DashCont
 pub fn dash_along_glif<PD: PointData>(glif: &Glif<PD>, settings: &DashContour) -> Glif<PD> {
     let mut glif = glif.clone();
 
-    let final_output = match glif.outline.as_ref().map(|o|dash_along_path(o, settings)) {
+    let final_output = match glif.outline.as_ref().map(|o| dash_along_path(o, settings)) {
         Some(fo) => fo,
-        None => return glif.clone()
+        None => return glif,
     };
 
     glif.outline = Some(final_output);

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,6 +1,6 @@
-use super::vector::Vector;
-use super::rect::Rect;
 use super::coordinate::Coordinate;
+use super::rect::Rect;
+use super::vector::Vector;
 
 use crate::vec2;
 
@@ -8,13 +8,14 @@ use crate::vec2;
 // can be evaluated with respect to time t and return an x, y pair. It also needs to be able to give us
 // a derivative and a bounding box.
 // Could probably use a better name. Maybe Primitive as they're the building blocks of our glyph.
-pub trait Evaluate
-{
-    type EvalResult: Coordinate+Send+Sync;
-    fn at(&self, t: f64) -> Self::EvalResult; 
+pub trait Evaluate {
+    type EvalResult: Coordinate + Send + Sync;
+    fn at(&self, t: f64) -> Self::EvalResult;
     fn tangent_at(&self, u: f64) -> Self::EvalResult;
-    fn bounds(&self) -> Rect; // returns an AABB that contains all points 
-    fn apply_transform<F: Send+Sync>(&self, transform: F) -> Self where F: Fn(&Self::EvalResult) -> Self::EvalResult;
+    fn bounds(&self) -> Rect; // returns an AABB that contains all points
+    fn apply_transform<F: Send + Sync>(&self, transform: F) -> Self
+    where
+        F: Fn(&Self::EvalResult) -> Self::EvalResult;
     fn start_point(&self) -> Self::EvalResult;
     fn end_point(&self) -> Self::EvalResult;
 }
@@ -31,33 +32,24 @@ pub trait EvalRotate: Evaluate {
     fn rotate(&self, angle: f64) -> Self;
 }
 
-impl<T: Evaluate+Send+Sync> EvalTranslate for T{
-    fn translate(&self, t: T::EvalResult) -> Self
-    {
-        let transform = |v: &T::EvalResult| {
-            return *v + t;
-        };
-    
-        return self.apply_transform(&transform);
+impl<T: Evaluate + Send + Sync> EvalTranslate for T {
+    fn translate(&self, t: T::EvalResult) -> Self {
+        let transform = |v: &T::EvalResult| *v + t;
+
+        self.apply_transform(&transform)
     }
 }
 
-impl<T: Evaluate> EvalScale for T{
-    fn scale(&self, s: T::EvalResult) -> Self
-    {
-    
-        let transform = |v: &T::EvalResult| {
-            return *v * s;
-        };
+impl<T: Evaluate> EvalScale for T {
+    fn scale(&self, s: T::EvalResult) -> Self {
+        let transform = |v: &T::EvalResult| *v * s;
 
-        return self.apply_transform(&transform);
+        self.apply_transform(&transform)
     }
 }
 
 impl<T: Evaluate<EvalResult = Vector>> EvalRotate for T {
-
-    fn rotate(&self, angle: f64) -> Self 
-    {
+    fn rotate(&self, angle: f64) -> Self {
         let transform = |v: &T::EvalResult| {
             return vec2!(
                 v.x * f64::cos(angle) - v.y * f64::sin(angle),
@@ -65,6 +57,6 @@ impl<T: Evaluate<EvalResult = Vector>> EvalRotate for T {
             );
         };
 
-        return self.apply_transform(&transform);
+        self.apply_transform(&transform)
     }
 }

--- a/src/fit_to_points/get_control_points.rs
+++ b/src/fit_to_points/get_control_points.rs
@@ -22,9 +22,8 @@ pub fn get_curve_control_point(knots: Contour<()>) -> (Vec<(f32, f32)>, Vec<(f32
     } else {
         // Calculate first Bezier control points
         // Right hand side vector
-        let mut rhs = Vec::<f32>::new();
         // Set right hand side X values
-        rhs.push(knots[0].x + 2. * knots[1].x);
+        let mut rhs = vec![knots[0].x + 2. * knots[1].x];
         for i in 1..(n - 1) {
             rhs.push(4. * knots[i].x + 2. * knots[i + 1].x);
         }

--- a/src/glyphbuilder/mod.rs
+++ b/src/glyphbuilder/mod.rs
@@ -9,7 +9,7 @@ use crate::{Bezier, EvalRotate, EvalScale, EvalTranslate, Evaluate, Piecewise, P
 
 #[allow(unused)]
 fn vec2_to_rad(vec: Vector) -> f64 {
-    return f64::atan2(vec.y, vec.x);
+    f64::atan2(vec.y, vec.x)
 }
 
 fn normalize_angle(angle: f64) -> f64 {
@@ -26,13 +26,11 @@ fn normalize_angle(angle: f64) -> f64 {
 
 #[allow(unused)]
 fn delta_angle(start: f64, end: f64, direction: f64) -> f64 {
-    let difference = if direction == 1. {
+    if direction == 1. {
         start - end
     } else {
         end - start
-    };
-
-    difference
+    }
 }
 
 pub struct GlyphBuilder {
@@ -41,9 +39,9 @@ pub struct GlyphBuilder {
 
 impl GlyphBuilder {
     pub fn new() -> Self {
-        return Self {
+        Self {
             beziers: Vec::new(),
-        };
+        }
     }
 
     pub fn append(&mut self, other: GlyphBuilder) {
@@ -72,7 +70,7 @@ impl GlyphBuilder {
     }
 
     pub fn bevel_to(&mut self, to: Vector, _tangent1: Vector, _tangent2: Vector) {
-        return self.line_to(to);
+        self.line_to(to)
     }
 
     pub fn miter_to(&mut self, to: Vector, tangent1: Vector, tangent2: Vector) {
@@ -322,7 +320,7 @@ impl GlyphBuilder {
         let ray1 = (from, from + tangent1 * 200.);
         let ray2 = (to, to + tangent2 * 200.);
 
-        return line_intersects_line(&ray1, &ray2);
+        line_intersects_line(&ray1, &ray2)
     }
 
     pub fn fuse_nearby_ends(&self, distance: f64) -> GlyphBuilder {
@@ -345,8 +343,8 @@ impl GlyphBuilder {
             new_segments.push(primitive.clone());
         }
 
-        return GlyphBuilder {
+        GlyphBuilder {
             beziers: new_segments,
-        };
+        }
     }
 }

--- a/src/interpolator/evaluate.rs
+++ b/src/interpolator/evaluate.rs
@@ -1,47 +1,43 @@
-use super::Interpolator;
-use super::super::Vector;
 use super::super::Evaluate;
 use super::super::Rect;
+use super::super::Vector;
+use super::Interpolator;
 use crate::vec2;
 
-impl Evaluate for Interpolator
-{
+impl Evaluate for Interpolator {
     type EvalResult = f64;
-    
-    fn at(&self, t: f64) -> f64
-    {
+
+    fn at(&self, t: f64) -> f64 {
         let interpolate_func = &self.func;
-        return interpolate_func(self, t);
+        interpolate_func(self, t)
     }
 
     // Everything below this point should probably be moved into it's own trait sometime soon because
     // these functions don't exactly make sense here.
-    fn tangent_at(&self, _t: f64) -> f64
-    {
-        return 0.;
+    fn tangent_at(&self, _t: f64) -> f64 {
+        0.
     }
 
-    fn apply_transform<F>(&self, transform: F) -> Self where F: Fn(&f64) -> f64
+    fn apply_transform<F>(&self, transform: F) -> Self
+    where
+        F: Fn(&f64) -> f64,
     {
-        return Self {
+        Self {
             start: transform(&self.start),
             finish: transform(&self.finish),
-            func: self.func
+            func: self.func,
         }
     }
 
-    fn bounds(&self) -> Rect
-    {
-        return Rect::AABB_from_points(vec![vec2!(self.start, self.finish)]);
+    fn bounds(&self) -> Rect {
+        Rect::AABB_from_points(vec![vec2!(self.start, self.finish)])
     }
 
-    fn start_point(&self) -> Self::EvalResult
-    {
-        return self.start;
+    fn start_point(&self) -> Self::EvalResult {
+        self.start
     }
 
-    fn end_point(&self) -> Self::EvalResult
-    {
-        return self.finish;
+    fn end_point(&self) -> Self::EvalResult {
+        self.finish
     }
 }

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -1,10 +1,9 @@
 mod evaluate;
 
-pub struct Interpolator
-{
+pub struct Interpolator {
     start: f64,
     finish: f64,
-    func: fn(&Self, f64) -> f64
+    func: fn(&Self, f64) -> f64,
 }
 
 #[derive(Clone, Copy)]
@@ -15,49 +14,45 @@ pub enum InterpolationType {
 
 impl Interpolator {
     fn interpolate_none(&self, _t: f64) -> f64 {
-        return self.start;
+        self.start
     }
 
     fn interpolate_linear(&self, t: f64) -> f64 {
-        return (1. - t) * self.start + t * self.finish;
+        (1. - t) * self.start + t * self.finish
     }
-    
+
     fn interpolate_exponential(&self, t: f64) -> f64 {
-        return self.start + (self.finish - self.start) * t * t;
+        self.start + (self.finish - self.start) * t * t
     }
 
-    pub fn new(start: f64, finish:f64, kind: InterpolationType) -> Self
-    {
+    pub fn new(start: f64, finish: f64, kind: InterpolationType) -> Self {
         match kind {
-            InterpolationType::Null => return Self::new_none(start, finish),
-            InterpolationType::Linear => return Self::new_linear(start, finish),
+            InterpolationType::Null => Self::new_none(start, finish),
+            InterpolationType::Linear => Self::new_linear(start, finish),
         }
     }
 
-    pub fn new_none(start: f64, finish: f64) -> Self
-    {
+    pub fn new_none(start: f64, finish: f64) -> Self {
         Interpolator {
             start,
             finish,
-            func: Self::interpolate_none
+            func: Self::interpolate_none,
         }
     }
 
-    pub fn new_linear(start: f64, finish: f64) -> Self
-    {
+    pub fn new_linear(start: f64, finish: f64) -> Self {
         Interpolator {
             start,
             finish,
-            func: Self::interpolate_linear
+            func: Self::interpolate_linear,
         }
     }
 
-    pub fn new_exponential(start: f64, finish: f64) -> Self
-    {
+    pub fn new_exponential(start: f64, finish: f64) -> Self {
         Interpolator {
             start,
             finish,
-            func: Self::interpolate_exponential
+            func: Self::interpolate_exponential,
         }
     }
 }

--- a/src/piecewise/glif.rs
+++ b/src/piecewise/glif.rs
@@ -1,42 +1,37 @@
 use super::{Bezier, Piecewise, Vector};
-use glifparser::{Contour, Outline, Handle, PointType};
-#[cfg(feature="default")]
+#[cfg(feature = "default")]
 use glifparser::glif::{MFEKContour, MFEKOutline};
+use glifparser::{Contour, Handle, Outline, PointType};
 
-impl<T: glifparser::PointData> From<&Outline<T>> for Piecewise<Piecewise<Bezier>>
-{
-    fn from(outline: &Outline<T>) -> Self { 
+impl<T: glifparser::PointData> From<&Outline<T>> for Piecewise<Piecewise<Bezier>> {
+    fn from(outline: &Outline<T>) -> Self {
         let mut new_segs = Vec::new();
 
-        for contour in outline
-        {
+        for contour in outline {
             new_segs.push(Piecewise::from(contour));
         }
-    
-        return Piecewise::new(new_segs, None);
+
+        Piecewise::new(new_segs, None)
     }
 }
 
-#[cfg(feature="default")]
-impl<T: glifparser::PointData> From<&MFEKOutline<T>> for Piecewise<Piecewise<Bezier>>
-{
-    fn from(outline: &MFEKOutline<T>) -> Self { 
+#[cfg(feature = "default")]
+impl<T: glifparser::PointData> From<&MFEKOutline<T>> for Piecewise<Piecewise<Bezier>> {
+    fn from(outline: &MFEKOutline<T>) -> Self {
         let mut new_segs = Vec::new();
 
-        for contour in outline
-        {
+        for contour in outline {
             new_segs.push(Piecewise::from(contour));
         }
-    
-        return Piecewise::new(new_segs, None);
+
+        Piecewise::new(new_segs, None)
     }
 }
 
-#[cfg(feature="default")]
-impl<T: glifparser::PointData> From<MFEKOutline<T>> for Piecewise<Piecewise<Bezier>>
-{
-    fn from(outline: MFEKOutline<T>) -> Self { 
-        return outline.into();
+#[cfg(feature = "default")]
+impl<T: glifparser::PointData> From<MFEKOutline<T>> for Piecewise<Piecewise<Bezier>> {
+    fn from(outline: MFEKOutline<T>) -> Self {
+        outline.into()
     }
 }
 
@@ -44,29 +39,25 @@ impl Piecewise<Piecewise<Bezier>> {
     pub fn to_outline<T: glifparser::PointData>(&self) -> Outline<T> {
         let mut output_outline: Outline<T> = Outline::new();
 
-        for contour in &self.segs
-        {
+        for contour in &self.segs {
             output_outline.push(contour.to_contour());
         }
 
-        return output_outline;
+        output_outline
     }
 }
 
-impl<T: glifparser::PointData> From<&Contour<T>> for Piecewise<Bezier>
-{
+impl<T: glifparser::PointData> From<&Contour<T>> for Piecewise<Bezier> {
     fn from(contour: &Contour<T>) -> Self {
         let mut new_segs = Vec::new();
 
         let mut lastpoint: Option<&glifparser::Point<T>> = None;
 
-        for point in contour
-        {
-            match lastpoint
-            {
-                None => {},
+        for point in contour {
+            match lastpoint {
+                None => {}
                 Some(lastpoint) => {
-                    new_segs.push(Bezier::from(&lastpoint, point));
+                    new_segs.push(Bezier::from(lastpoint, point));
                 }
             }
 
@@ -75,26 +66,24 @@ impl<T: glifparser::PointData> From<&Contour<T>> for Piecewise<Bezier>
 
         let firstpoint = contour.first().unwrap();
         if firstpoint.ptype != PointType::Move {
-            new_segs.push(Bezier::from(&lastpoint.unwrap(), firstpoint));
+            new_segs.push(Bezier::from(lastpoint.unwrap(), firstpoint));
         }
 
-        return Piecewise::new(new_segs, None);
+        Piecewise::new(new_segs, None)
     }
 }
 
-#[cfg(feature="default")]
-impl<T: glifparser::PointData> From<&MFEKContour<T>> for Piecewise<Bezier>
-{
+#[cfg(feature = "default")]
+impl<T: glifparser::PointData> From<&MFEKContour<T>> for Piecewise<Bezier> {
     fn from(contour: &MFEKContour<T>) -> Self {
-        return Piecewise::from(&contour.inner);
+        Piecewise::from(&contour.inner)
     }
 }
 
-#[cfg(feature="default")]
-impl<T: glifparser::PointData> From<MFEKContour<T>> for Piecewise<Bezier>
-{
+#[cfg(feature = "default")]
+impl<T: glifparser::PointData> From<MFEKContour<T>> for Piecewise<Bezier> {
     fn from(contour: MFEKContour<T>) -> Self {
-        return Piecewise::from(&contour.inner);
+        Piecewise::from(&contour.inner)
     }
 }
 
@@ -107,15 +96,20 @@ impl Piecewise<Bezier> {
         for curve in &self.segs {
             let control_points = curve.to_control_points();
 
-            let point_type = if first_point && !self.is_closed() { PointType::Move } else { PointType::Curve };
-            let mut new_point = control_points[0].to_point(control_points[1].to_handle(), Handle::Colocated, point_type);
+            let point_type = if first_point && !self.is_closed() {
+                PointType::Move
+            } else {
+                PointType::Curve
+            };
+            let mut new_point = control_points[0].to_point(
+                control_points[1].to_handle(),
+                Handle::Colocated,
+                point_type,
+            );
 
             // if this isn't the first point we need to backtrack and set our output point's b handle
-            match last_curve {
-                Some(lc) => {
-                    new_point.b = lc[2].to_handle();
-                }
-                None => {}
+            if let Some(lc) = last_curve {
+                new_point.b = lc[2].to_handle();
             }
 
             output_contour.push(new_point);
@@ -124,7 +118,9 @@ impl Piecewise<Bezier> {
             first_point = false;
         }
 
-        if output_contour.len() <= 1 { return output_contour }
+        if output_contour.len() <= 1 {
+            return output_contour;
+        }
 
         if self.is_closed() {
             let fp = output_contour.first_mut().unwrap();
@@ -133,10 +129,14 @@ impl Piecewise<Bezier> {
             fp.b = Vector::to_handle(last_curve.unwrap()[2]);
         } else {
             let control_points = last_curve.unwrap();
-            let new_point = control_points[3].to_point(control_points[2].to_handle(), Handle::Colocated, PointType::Curve);
+            let new_point = control_points[3].to_point(
+                control_points[2].to_handle(),
+                Handle::Colocated,
+                PointType::Curve,
+            );
             output_contour.push(new_point);
         }
-    
+
         output_contour
     }
 }

--- a/src/piecewise/skia.rs
+++ b/src/piecewise/skia.rs
@@ -1,13 +1,12 @@
-use super::super::vector::Vector;
 use super::super::bezier::Bezier;
 use super::super::piecewise::Piecewise;
+use super::super::vector::Vector;
 use skia_safe::{path, Path};
 
-impl Piecewise<Piecewise<Bezier>>
-{
+impl Piecewise<Piecewise<Bezier>> {
     pub fn to_skpath(self) -> Path {
         let path = Path::new();
-        return self.append_to_skpath(path);
+        self.append_to_skpath(path)
     }
 
     pub fn append_to_skpath(&self, mut skpath: Path) -> Path {
@@ -15,14 +14,12 @@ impl Piecewise<Piecewise<Bezier>>
             skpath = contour.append_to_skpath(skpath);
         }
 
-        return skpath;
+        skpath
     }
 }
 
-impl Piecewise<Bezier>
-{
-    pub fn append_to_skpath(&self, mut skpath: Path) -> Path
-    {
+impl Piecewise<Bezier> {
+    pub fn append_to_skpath(&self, mut skpath: Path) -> Path {
         let mut first = true;
         for bez in &self.segs {
             let controlp = bez.to_control_points();
@@ -31,45 +28,48 @@ impl Piecewise<Bezier>
                 skpath.move_to(controlp[0].to_skia_point());
                 first = false;
             }
-            
+
             // we've got ourselves a line
             if controlp[0] == controlp[2] && controlp[1] == controlp[3] {
                 skpath.line_to(controlp[3].to_skia_point());
             }
 
-            skpath.cubic_to(controlp[1].to_skia_point(), controlp[2].to_skia_point(), controlp[3].to_skia_point());
+            skpath.cubic_to(
+                controlp[1].to_skia_point(),
+                controlp[2].to_skia_point(),
+                controlp[3].to_skia_point(),
+            );
         }
 
-        return skpath;
+        skpath
     }
 }
 
-impl From<&Path> for Piecewise<Piecewise<Bezier>>
-{
+impl From<&Path> for Piecewise<Piecewise<Bezier>> {
     fn from(ipath: &Path) -> Self {
         let mut contours: Vec<Piecewise<Bezier>> = Vec::new();
         let iter = path::Iter::new(ipath, false);
-    
+
         let mut cur_contour: Vec<Bezier> = Vec::new();
-        let mut last_point: Vector = Vector{x: 0., y: 0.}; // don't think we need this?
+        let mut last_point: Vector = Vector { x: 0., y: 0. }; // don't think we need this?
         for (v, vp) in iter {
             match v {
                 path::Verb::Move => {
                     if !cur_contour.is_empty() {
                         contours.push(Piecewise::new(cur_contour, None));
                     }
-    
-                    cur_contour = Vec::new();  
+
+                    cur_contour = Vec::new();
                     last_point = Vector::from_skia_point(vp.first().unwrap());
                 }
-    
+
                 path::Verb::Line => {
                     let lp = Vector::from_skia_point(&vp[0]);
                     let np = Vector::from_skia_point(&vp[1]);
                     cur_contour.push(Bezier::from_points(lp, lp, np, np));
                     last_point = np;
                 }
-    
+
                 path::Verb::Quad => {
                     let lp = last_point;
                     let h2 = Vector::from_skia_point(&vp[0]);
@@ -77,7 +77,7 @@ impl From<&Path> for Piecewise<Piecewise<Bezier>>
                     cur_contour.push(Bezier::from_points(lp, lp, h2, np));
                     last_point = np;
                 }
-    
+
                 path::Verb::Cubic => {
                     let lp = Vector::from_skia_point(&vp[0]);
                     let h1 = Vector::from_skia_point(&vp[1]);
@@ -86,23 +86,25 @@ impl From<&Path> for Piecewise<Piecewise<Bezier>>
                     cur_contour.push(Bezier::from_points(lp, h1, h2, np));
                     last_point = np;
                 }
-    
+
                 path::Verb::Close => {
                     contours.push(Piecewise::new(cur_contour.clone(), None));
                     cur_contour = Vec::new();
                 }
-                
-    
+
                 // I might have to implement more verbs, but at the moment we're just converting
                 // from glifparser output and these are all the supported primitives there.
-                _ => { println!("{:?} {:?}", v, vp); panic!("Unsupported skia verb in skpath!"); }
+                _ => {
+                    println!("{:?} {:?}", v, vp);
+                    panic!("Unsupported skia verb in skpath!");
+                }
             }
         }
-    
+
         if !cur_contour.is_empty() {
             contours.push(Piecewise::new(cur_contour, None));
         }
-    
-        return Piecewise::new(contours, None);
+
+        Piecewise::new(contours, None)
     }
 }

--- a/src/polar.rs
+++ b/src/polar.rs
@@ -1,5 +1,4 @@
 /// This module adds math functions to types in glifparser.
-
 use glifparser::{Handle, Point, PointData, PointType, WhichHandle};
 
 use std::f32::consts;
@@ -22,14 +21,19 @@ impl Bezier {
         let (p, h) = match wh {
             WhichHandle::A => (self.w1, self.w2),
             WhichHandle::B => (self.w4, self.w3),
-            WhichHandle::Neither => unreachable!()
+            WhichHandle::Neither => unreachable!(),
         };
-        let mut gp: Point<()> = Vector::to_point(p, Handle::Colocated, Handle::Colocated, PointType::Line);
+        let mut gp: Point<()> =
+            Vector::to_point(p, Handle::Colocated, Handle::Colocated, PointType::Line);
         let gh: Handle = Vector::to_handle(h);
         match wh {
-            WhichHandle::A => {gp.a = gh;},
-            WhichHandle::B => {gp.b = gh;},
-            WhichHandle::Neither => unreachable!()
+            WhichHandle::A => {
+                gp.a = gh;
+            }
+            WhichHandle::B => {
+                gp.b = gh;
+            }
+            WhichHandle::Neither => unreachable!(),
         }
         gp
     }
@@ -50,20 +54,20 @@ impl PolarCoordinates for Bezier {
         let h = &mut match wh {
             WhichHandle::A => self.w2,
             WhichHandle::B => self.w3,
-            WhichHandle::Neither => unreachable!()
+            WhichHandle::Neither => unreachable!(),
         };
         h.x = p.x as f64;
         h.y = p.y as f64;
     }
 }
 
-use WhichHandle::{A, B, Neither};
+use WhichHandle::{Neither, A, B};
 impl<PD: PointData> PolarCoordinates for Point<PD> {
     fn cartesian(&self, wh: WhichHandle) -> (f32, f32) {
         let (x, y) = match wh {
             Neither => (self.x, self.y),
-            A => self.handle_or_colocated(WhichHandle::A, &|f|f, &|f|f),
-            B => self.handle_or_colocated(WhichHandle::B, &|f|f, &|f|f),
+            A => self.handle_or_colocated(WhichHandle::A, &|f| f, &|f| f),
+            B => self.handle_or_colocated(WhichHandle::B, &|f| f, &|f| f),
         };
         (self.x - x, self.y - y)
     }
@@ -78,9 +82,16 @@ impl<PD: PointData> PolarCoordinates for Point<PD> {
         let y = self.y + (r * (theta * (consts::PI / 180.)).sin());
 
         match wh {
-            Neither => {self.x = x; self.y = y;},
-            A => {self.a = Handle::At(x, y);},
-            B => {self.b = Handle::At(x, y);},
+            Neither => {
+                self.x = x;
+                self.y = y;
+            }
+            A => {
+                self.a = Handle::At(x, y);
+            }
+            B => {
+                self.b = Handle::At(x, y);
+            }
         };
     }
 }

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -2,16 +2,16 @@ use crate::bezier::Bezier;
 use crate::vector::Vector;
 
 // This trait is implemented for a primitive shape like a line, bezier, spiro, etc within the piecewise.
-pub trait Primitive: Sized + Clone
-{
-    fn subdivide(&self, t: f64) -> Option<(Self, Self)> where Self: Sized;
+pub trait Primitive: Sized + Clone {
+    fn subdivide(&self, t: f64) -> Option<(Self, Self)>
+    where
+        Self: Sized;
 }
 
 impl Primitive for Bezier {
     // returns two curves one before t and one after
     // https://www.malinc.se/m/DeCasteljauAndBezier.php
-    fn subdivide(&self,  t:f64) -> Option<(Self, Self)>
-    {
+    fn subdivide(&self, t: f64) -> Option<(Self, Self)> {
         if t == 0. || t == 1. {
             // if we're really close to 0 or 1 it doesn't make sense to split
             return None;
@@ -21,7 +21,7 @@ impl Primitive for Bezier {
         // it's just a bit of lerping
         let points = self.to_control_points();
 
-        // We lerp between the control points and their handles 
+        // We lerp between the control points and their handles
         let q0 = Vector::lerp(points[0], points[1], t);
         let q1 = Vector::lerp(points[1], points[2], t);
         let q2 = Vector::lerp(points[2], points[3], t);
@@ -38,6 +38,6 @@ impl Primitive for Bezier {
         let first = Self::from_points(points[0], q0, r0, s0);
         let second = Self::from_points(s0, r1, q2, points[3]);
 
-        return Some((first, second));
+        Some((first, second))
     }
 }

--- a/src/rect/mod.rs
+++ b/src/rect/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(feature="default")]
+#[cfg(feature = "default")]
 mod flip_if_required;
-#[cfg(feature="default")]
+#[cfg(feature = "default")]
 pub use flip_if_required::FlipIfRequired;
 
 use super::vector::Vector;
@@ -11,65 +11,80 @@ pub struct Rect {
     pub top: f64,
     pub bottom: f64,
     pub left: f64,
-    pub right: f64
+    pub right: f64,
 }
 
 impl Rect {
     // We expand the rect to be the minimum axis aligned bounding box that holds both our current rect and the point.
-    pub fn encapsulate(&self, p: Vector) -> Rect
-    {
+    pub fn encapsulate(&self, p: Vector) -> Rect {
         let mut lx = self.left;
         let mut ly = self.bottom;
         let mut hx = self.right;
         let mut hy = self.top;
-    
-        if p.x > hx { hx = p.x }
-        if p.y > hy { hy = p.y }
-        if p.x < lx { lx = p.x }
-        if p.y < ly { ly = p.y }
-    
-        return Rect {
+
+        if p.x > hx {
+            hx = p.x
+        }
+        if p.y > hy {
+            hy = p.y
+        }
+        if p.x < lx {
+            lx = p.x
+        }
+        if p.y < ly {
+            ly = p.y
+        }
+
+        Rect {
             left: lx,
             right: hx,
             top: hy,
-            bottom: ly
-        };
+            bottom: ly,
+        }
     }
 
     // Taje a vec of points and return a minimum bounding box for that point.
     #[allow(non_snake_case)]
-    pub fn AABB_from_points(points: Vec<Vector>) -> Self
-    {
+    pub fn AABB_from_points(points: Vec<Vector>) -> Self {
         let mut lx = f64::INFINITY;
         let mut ly = f64::INFINITY;
         let mut hx = -f64::INFINITY;
         let mut hy = -f64::INFINITY;
-    
+
         for p in points {
-            if p.x > hx { hx = p.x }
-            if p.y > hy { hy = p.y }
-            if p.x < lx { lx = p.x }
-            if p.y < ly { ly = p.y }
+            if p.x > hx {
+                hx = p.x
+            }
+            if p.y > hy {
+                hy = p.y
+            }
+            if p.x < lx {
+                lx = p.x
+            }
+            if p.y < ly {
+                ly = p.y
+            }
         }
-    
-        return Rect {
+
+        Rect {
             left: lx,
             right: hx,
             top: hy,
-            bottom: ly
-        };
+            bottom: ly,
+        }
     }
 
     pub fn area(&self) -> f64 {
-        (self.right - self.left) *  (self.top - self.bottom)
+        (self.right - self.left) * (self.top - self.bottom)
     }
 
     pub fn overlaps(&self, other: &Rect) -> bool {
-        if  self.bottom < other.top &&
-            self.top > other.bottom &&
-            self.left < other.right &&
-            self.right > other.left {
-               return true;
+        if self.bottom < other.top
+            && self.top > other.bottom
+            && self.left < other.right
+            && self.right > other.left
+        {
+            return true;
         }
         false
     }
@@ -84,11 +99,16 @@ impl Rect {
         }
     }
 
-    pub fn encapsulate_rect(&self, other: Rect) -> Rect
-    {
-        let left_bottom = Vector{x: other.left, y: other.bottom};
-        let right_top = Vector{x: other.right, y: other.top};
-        return self.encapsulate(left_bottom).encapsulate(right_top)
+    pub fn encapsulate_rect(&self, other: Rect) -> Rect {
+        let left_bottom = Vector {
+            x: other.left,
+            y: other.bottom,
+        };
+        let right_top = Vector {
+            x: other.right,
+            y: other.top,
+        };
+        self.encapsulate(left_bottom).encapsulate(right_top)
     }
 
     pub fn width(&self) -> f64 {
@@ -103,6 +123,6 @@ impl Rect {
         let left_bottom = Vector::from_components(self.left, self.bottom);
         let right_top = Vector::from_components(self.right, self.top);
 
-        return left_bottom.lerp(right_top, 0.5);
+        left_bottom.lerp(right_top, 0.5)
     }
 }

--- a/src/variable_width_stroking/mod.rs
+++ b/src/variable_width_stroking/mod.rs
@@ -1,9 +1,12 @@
 use std::collections::VecDeque;
 
-use super::{Bezier, Evaluate, Piecewise, Vector, GlyphBuilder};
 use super::consts::SMALL_DISTANCE;
-use glifparser::{Glif, JoinType, Outline, PointData, VWSContour, glif::{CapType, InterpolationType, VWSHandle}};
+use super::{Bezier, Evaluate, GlyphBuilder, Piecewise, Vector};
 use glifparser::glif::Lib as GlifLib;
+use glifparser::{
+    glif::{CapType, InterpolationType, VWSHandle},
+    Glif, JoinType, Outline, PointData, VWSContour,
+};
 
 #[derive(Debug)]
 pub struct VWSSettings<PD: PointData> {
@@ -13,15 +16,14 @@ pub struct VWSSettings<PD: PointData> {
 
 // we want to deal with colocated handles here so that we don't get funky results at caps and joins
 // where one or more handles is colocated
-fn preprocess_path(in_pw: &Piecewise<Bezier>) -> Piecewise<Bezier>
-{
+fn preprocess_path(in_pw: &Piecewise<Bezier>) -> Piecewise<Bezier> {
     let in_pw = in_pw.remove_short_segs(0.01, 3);
     let mut out_contours = Vec::new();
 
     for bez in &in_pw.segs {
         let mut new_bez = bez.clone();
 
-        let distance_heuristic = bez.w1.distance(bez.w4)/12.;
+        let distance_heuristic = bez.w1.distance(bez.w4) / 12.;
         if bez.w1.distance(bez.w2) < distance_heuristic {
             new_bez.w2 = bez.at(0.40);
         }
@@ -33,60 +35,56 @@ fn preprocess_path(in_pw: &Piecewise<Bezier>) -> Piecewise<Bezier>
         out_contours.push(new_bez);
     }
 
-    return Piecewise {
+    Piecewise {
         segs: out_contours,
-        cuts: in_pw.cuts.clone()
+        cuts: in_pw.cuts.clone(),
     }
 }
 // takes a vector of beziers and fills in discontinuities with joins
-fn fix_path(in_path: GlyphBuilder, closed: bool, join_type: JoinType) -> GlyphBuilder
-{
+fn fix_path(in_path: GlyphBuilder, closed: bool, join_type: JoinType) -> GlyphBuilder {
     let mut out = GlyphBuilder::new();
 
     let join_to = match join_type {
         JoinType::Bevel => GlyphBuilder::bevel_to,
         JoinType::Round => GlyphBuilder::arc_to,
         JoinType::Circle => GlyphBuilder::circle_arc_to,
-        JoinType::Miter => GlyphBuilder::miter_to
+        JoinType::Miter => GlyphBuilder::miter_to,
     };
 
     let mut path_iter = in_path.beziers.iter().peekable();
-    
+
     while let Some(bezier) = path_iter.next() {
-        if let Some(next_bezier) = path_iter.peek()
-        {
+        if let Some(next_bezier) = path_iter.peek() {
             let next_start = next_bezier.start_point();
             let last_end = bezier.end_point();
-            if !last_end.is_near(next_start, SMALL_DISTANCE)
-            {
+            if !last_end.is_near(next_start, SMALL_DISTANCE) {
                 // the end of our last curve doesn't match up with the start of our next so we need to
                 // deal with the discontinuity be creating a join
                 let from_end_point = bezier.at(1.);
                 let to_start_point = next_bezier.at(0.);
-        
+
                 // used for round joins
-                let tangent1 = bezier.tangent_at(1.).normalize(); 
+                let tangent1 = bezier.tangent_at(1.).normalize();
                 let tangent2 = next_bezier.tangent_at(0.).normalize();
-        
+
                 let discontinuity_vec = to_start_point - from_end_point;
-                let dr =  Vector{x: discontinuity_vec.y, y: -discontinuity_vec.x}.normalize();
-        
+                let dr = Vector {
+                    x: discontinuity_vec.y,
+                    y: -discontinuity_vec.x,
+                }
+                .normalize();
+
                 let t1_dot_dr = tangent1.dot(dr);
                 let t2_dot_dr = tangent2.dot(dr);
-                let tangent1= if t1_dot_dr > 0. { tangent1 } else { -tangent1 };
-                let tangent2= if t2_dot_dr < 0. { tangent2 } else { -tangent2 };
-    
-                
+                let tangent1 = if t1_dot_dr > 0. { tangent1 } else { -tangent1 };
+                let tangent2 = if t2_dot_dr < 0. { tangent2 } else { -tangent2 };
+
                 out.bezier_to(bezier.clone());
                 join_to(&mut out, next_start, tangent1, tangent2);
-            }
-            else
-            {
+            } else {
                 out.bezier_to(bezier.clone());
             }
-        }
-        else if closed
-        {
+        } else if closed {
             // our path is closed and if there's not a next point we need to make sure that our current
             // and last curve matches up with the first one
 
@@ -94,9 +92,8 @@ fn fix_path(in_path: GlyphBuilder, closed: bool, join_type: JoinType) -> GlyphBu
             let first_point = first_bez.start_point();
             let last_end = bezier.end_point();
 
-            if !last_end.is_near(first_point, SMALL_DISTANCE)
-            {
-                let tangent1 = bezier.tangent_at(1.).normalize(); 
+            if !last_end.is_near(first_point, SMALL_DISTANCE) {
+                let tangent1 = bezier.tangent_at(1.).normalize();
                 let tangent2 = first_bez.tangent_at(0.).normalize();
                 let discontinuity_vec = first_point - last_end;
                 let on_outside = Vector::dot(tangent2, discontinuity_vec) <= 0.;
@@ -104,28 +101,26 @@ fn fix_path(in_path: GlyphBuilder, closed: bool, join_type: JoinType) -> GlyphBu
                 if !on_outside {
                     out.bezier_to(bezier.clone());
                     join_to(&mut out, first_point, tangent1, tangent2);
-                }
-                else
-                {
+                } else {
                     out.bezier_to(bezier.clone());
                     out.line_to(first_point);
                 }
-            }
-            else
-            {
+            } else {
                 out.bezier_to(bezier.clone());
             }
-        }
-        else
-        {
+        } else {
             out.bezier_to(bezier.clone());
         }
     }
 
-    return out;
+    out
 }
 
-pub fn variable_width_stroke<PD: PointData>(in_pw: &Piecewise<Bezier>, vws_contour: &VWSContour, settings: &VWSSettings<PD>) -> Piecewise<Piecewise<Bezier>> {
+pub fn variable_width_stroke<PD: PointData>(
+    in_pw: &Piecewise<Bezier>,
+    vws_contour: &VWSContour,
+    settings: &VWSSettings<PD>,
+) -> Piecewise<Piecewise<Bezier>> {
     let in_pw = preprocess_path(in_pw);
 
     let closed = in_pw.is_closed();
@@ -139,68 +134,81 @@ pub fn variable_width_stroke<PD: PointData>(in_pw: &Piecewise<Bezier>, vws_conto
     let iter = in_pw.segs.iter().enumerate();
     for (i, bezier) in iter {
         let cur_handle = &stroke_handles[i];
-        let next_handle = &stroke_handles[i+1];
+        let next_handle = &stroke_handles[i + 1];
 
         let left_start = cur_handle.left_offset;
         let right_start = cur_handle.right_offset;
 
         let left_end = match cur_handle.interpolation {
             InterpolationType::Null => left_start,
-            _ => next_handle.left_offset
+            _ => next_handle.left_offset,
         };
 
-        
         let right_end = match cur_handle.interpolation {
             InterpolationType::Null => right_start,
-            _ => next_handle.right_offset
+            _ => next_handle.right_offset,
         };
 
         let max_tangent_start = f64::max(cur_handle.right_offset, cur_handle.left_offset);
         let max_tangent_end = f64::max(next_handle.right_offset, next_handle.left_offset);
 
-        let left_ratio_start = cur_handle.left_offset/max_tangent_start;
-        let left_ratio_end = next_handle.left_offset/max_tangent_end;
+        let left_ratio_start = cur_handle.left_offset / max_tangent_start;
+        let left_ratio_end = next_handle.left_offset / max_tangent_end;
 
-        let right_ratio_start = cur_handle.right_offset/max_tangent_start;
-        let right_ratio_end = next_handle.right_offset/max_tangent_end;
+        let right_ratio_start = cur_handle.right_offset / max_tangent_start;
+        let right_ratio_end = next_handle.right_offset / max_tangent_end;
 
         let tangent_start = cur_handle.tangent_offset;
         let tangent_end = next_handle.tangent_offset;
 
-        let calc_t2 = |t| (1.-f64::cos(t*std::f64::consts::PI))/2.;
+        let calc_t2 = |t| (1. - f64::cos(t * std::f64::consts::PI)) / 2.;
 
         let left_normal_closure = |t| {
             let t2 = calc_t2(t);
-            return -left_start*(1.-t2)+-left_end*t2
+            -left_start * (1. - t2) + -left_end * t2
         };
 
         let left_tangent_closure = |t| {
             let t2 = calc_t2(t);
-            return -tangent_start*left_ratio_start*(1.-t2)+-tangent_end*left_ratio_end*t2
+            -tangent_start * left_ratio_start * (1. - t2) + -tangent_end * left_ratio_end * t2
         };
-        
+
         let right_normal_closure = |t| {
             let t2 = calc_t2(t);
-            return right_start*(1.-t2)+right_end*t2
+            right_start * (1. - t2) + right_end * t2
         };
 
         let right_tangent_closure = |t| {
             let t2 = calc_t2(t);
-            return tangent_start*right_ratio_start*(1.-t2)+tangent_end*right_ratio_end*t2
+            tangent_start * right_ratio_start * (1. - t2) + tangent_end * right_ratio_end * t2
         };
 
-        let left_offset = flo_curves::bezier::offset_lms_sampling(bezier, left_normal_closure, left_tangent_closure, 20, 4.0);
+        let left_offset = flo_curves::bezier::offset_lms_sampling(
+            bezier,
+            left_normal_closure,
+            left_tangent_closure,
+            20,
+            4.0,
+        );
         left_line.append_vec(left_offset.unwrap());
 
-        let right_offset = flo_curves::bezier::offset_lms_sampling(bezier, right_normal_closure, right_tangent_closure, 20, 4.0);
+        let right_offset = flo_curves::bezier::offset_lms_sampling(
+            bezier,
+            right_normal_closure,
+            right_tangent_closure,
+            20,
+            4.0,
+        );
         right_line.append_vec(right_offset.unwrap());
     }
-     
+
     right_line.beziers.reverse();
     right_line = GlyphBuilder {
-        beziers:    right_line.beziers.iter()
-                    .map(|bez| bez.clone().reverse())
-                    .collect()
+        beziers: right_line
+            .beziers
+            .iter()
+            .map(|bez| bez.clone().reverse())
+            .collect(),
     };
 
     right_line = right_line.fuse_nearby_ends(0.01);
@@ -221,41 +229,49 @@ pub fn variable_width_stroke<PD: PointData>(in_pw: &Piecewise<Bezier>, vws_conto
         if !vws_contour.remove_external {
             out.push(right_pw);
         }
-        
-        return Piecewise::new(out, None);
-    }
-    else
-    {
+
+        Piecewise::new(out, None)
+    } else {
         // path is not closed we need to cap the ends
         let mut out_builder = left_line;
 
         let from = out_builder.beziers.last().unwrap().clone();
         let to = right_line.beziers.first().unwrap().clone();
-        
+
         let from_end_point = from.at(1.);
         let to_start_point = to.at(0.);
 
         // used for round joins
-        let tangent1 = from.tangent_at(1.).normalize(); 
+        let tangent1 = from.tangent_at(1.).normalize();
         let tangent2 = -to.tangent_at(0.).normalize();
 
         let discontinuity_vec = to_start_point - from_end_point;
-        let dr =  Vector{x: discontinuity_vec.y, y: -discontinuity_vec.x}.normalize();
+        let dr = Vector {
+            x: discontinuity_vec.y,
+            y: -discontinuity_vec.x,
+        }
+        .normalize();
 
-        let tangent1= if tangent1.dot(dr) < 0.9 { dr } else { tangent1 };
-        let tangent2= if tangent2.dot(dr) > -0.9 { -dr } else { tangent2 };
+        let tangent1 = if tangent1.dot(dr) < 0.9 { dr } else { tangent1 };
+        let tangent2 = if tangent2.dot(dr) > -0.9 {
+            -dr
+        } else {
+            tangent2
+        };
 
         match vws_contour.cap_end_type {
             CapType::Round => out_builder.arc_to(to.start_point(), tangent1, tangent2),
             CapType::Circle => out_builder.circle_arc_to(to.start_point(), tangent1, tangent2),
             CapType::Square => out_builder.line_to(to.start_point()),
-            CapType::Custom => out_builder.cap_to(to.start_point(), settings.cap_custom_end.as_ref().unwrap())
+            CapType::Custom => {
+                out_builder.cap_to(to.start_point(), settings.cap_custom_end.as_ref().unwrap())
+            }
         }
 
         // append the right line to the left now that we've connected them
         out_builder.append(right_line);
 
-        // we need to close the beginning now 
+        // we need to close the beginning now
         let from = out_builder.beziers.last().unwrap().clone();
         let to = out_builder.beziers.first().unwrap().clone();
 
@@ -263,29 +279,42 @@ pub fn variable_width_stroke<PD: PointData>(in_pw: &Piecewise<Bezier>, vws_conto
         let to_start_point = to.at(0.);
 
         // used for round joins
-        let tangent1 = from.tangent_at(1.).normalize(); 
+        let tangent1 = from.tangent_at(1.).normalize();
         let tangent2 = -to.tangent_at(0.).normalize();
 
         let discontinuity_vec = to_start_point - from_end_point;
-        let dr =  Vector{x: discontinuity_vec.y, y: -discontinuity_vec.x}.normalize();
+        let dr = Vector {
+            x: discontinuity_vec.y,
+            y: -discontinuity_vec.x,
+        }
+        .normalize();
 
-        let tangent1= if tangent1.dot(dr) < 0.9 { dr } else { tangent1 };
-        let tangent2= if tangent2.dot(dr) > -0.9 { -dr } else { tangent2 };
+        let tangent1 = if tangent1.dot(dr) < 0.9 { dr } else { tangent1 };
+        let tangent2 = if tangent2.dot(dr) > -0.9 {
+            -dr
+        } else {
+            tangent2
+        };
 
         match vws_contour.cap_start_type {
             CapType::Round => out_builder.arc_to(to.start_point(), tangent1, tangent2),
             CapType::Circle => out_builder.circle_arc_to(to.start_point(), tangent1, tangent2),
             CapType::Square => out_builder.line_to(to.start_point()),
-            CapType::Custom => out_builder.cap_to(to.start_point(), settings.cap_custom_start.as_ref().unwrap())
+            CapType::Custom => out_builder.cap_to(
+                to.start_point(),
+                settings.cap_custom_start.as_ref().unwrap(),
+            ),
         }
 
         let inner = Piecewise::new(out_builder.beziers, None);
-        return Piecewise::new(vec![inner], None);
-    } 
+        Piecewise::new(vec![inner], None)
+    }
 }
 
-pub fn variable_width_stroke_glif<PD: glifparser::PointData>(path: &Glif<PD>, settings: VWSSettings<PD>) -> Glif<PD>
-{
+pub fn variable_width_stroke_glif<PD: glifparser::PointData>(
+    path: &Glif<PD>,
+    settings: VWSSettings<PD>,
+) -> Glif<PD> {
     // convert our path and pattern to piecewise collections of beziers
     let piece_path = Piecewise::from(path.outline.as_ref().unwrap());
     let mut output_outline: Outline<PD> = Vec::new();
@@ -295,53 +324,48 @@ pub fn variable_width_stroke_glif<PD: glifparser::PointData>(path: &Glif<PD>, se
     if handles.is_none() {
         panic!("No vws contours found in input!")
     }
-    
+
     let handles = handles.expect("Input glyph has no lib node!");
 
     let iter = piece_path.segs.iter().enumerate();
     for (i, pwpath_contour) in iter {
         let vws_contour = &handles.get(i);
-        
+
         if let Some(contour) = vws_contour {
             let results = variable_width_stroke(&pwpath_contour, &contour, &settings);
             for result_contour in results.segs {
                 output_outline.push(result_contour.to_contour());
             }
-        }
-        else
-        {
+        } else {
             output_outline.push(pwpath_contour.to_contour());
         }
     }
-    
-    return Glif {
+
+    Glif {
         outline: Some(output_outline),
         order: path.order, // default when only corners
         anchors: path.anchors.clone(),
-        width: path.width,
-        unicode: path.unicode.clone(),
-        name: path.name.clone(),
-        lib: generate_applied_vws_lib(&handles),
         components: path.components.clone(),
         guidelines: path.guidelines.clone(),
         images: path.images.clone(),
+        width: path.width,
+        unicode: path.unicode.clone(),
+        name: path.name.clone(),
         note: path.note.clone(),
         filename: path.filename.clone(),
-        ..Glif::default()
-    };
+        lib: generate_applied_vws_lib(&handles),
+    }
 }
 
-pub fn find_vws_contour(id: usize, vws_outline: &Vec<VWSContour>) -> Option<&VWSContour>
-{
-    return vws_outline.get(id);
+pub fn find_vws_contour(id: usize, vws_outline: &Vec<VWSContour>) -> Option<&VWSContour> {
+    vws_outline.get(id)
 }
 
-pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VWSContour>>
-{
+pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VWSContour>> {
     let lib = if let GlifLib::Plist(ref lib) = input.lib {
         lib
     } else {
-        return None
+        return None;
     };
     if let Some(lib) = lib.get("io.MFEK.variable_width_stroke") {
         let mut vd: VecDeque<_> = lib.as_array().unwrap().clone().into();
@@ -361,13 +385,13 @@ pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VW
                 .expect("VWSContour->cap_start wrong type")
                 .as_string()
                 .expect("VWSContour must have a cap_start");
-            
+
             let cap_end = vws
                 .get("cap_end")
                 .expect("VWSContour->cap_end wrong type")
                 .as_string()
                 .expect("VWSContour must have a cap_end");
-            
+
             let join = vws
                 .get("join")
                 .expect("VWSContour->join wrong type")
@@ -379,15 +403,15 @@ pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VW
                 "circle" => CapType::Circle,
                 "square" => CapType::Square,
                 "custom" => CapType::Custom,
-                _ => panic!("Invalid start cap type!")
+                _ => panic!("Invalid start cap type!"),
             };
-            
+
             let cap_end_type = match cap_end {
                 "round" => CapType::Round,
                 "circle" => CapType::Circle,
                 "square" => CapType::Square,
                 "custom" => CapType::Custom,
-                _ => panic!("Invalid end cap type!")
+                _ => panic!("Invalid end cap type!"),
             };
 
             let join_type = match join {
@@ -395,7 +419,7 @@ pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VW
                 "circle" => JoinType::Circle,
                 "miter" => JoinType::Miter,
                 "bevel" => JoinType::Bevel,
-                _ => panic!("Invalid join type!")
+                _ => panic!("Invalid join type!"),
             };
 
             let mut vws_handles = VWSContour {
@@ -407,7 +431,8 @@ pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VW
                 remove_external: false,
             };
 
-            let mut handles: VecDeque<_> = vws.get("handles")
+            let mut handles: VecDeque<_> = vws
+                .get("handles")
                 .expect("No handles in VWSContour?")
                 .as_array()
                 .expect("VWSContour->handles wrong type")
@@ -443,31 +468,31 @@ pub fn parse_vws_lib<T: glifparser::PointData>(input: &Glif<T>) -> Option<Vec<VW
 
                 let interpolation = match interpolation_string {
                     "linear" => InterpolationType::Linear,
-                    _ => InterpolationType::Null
+                    _ => InterpolationType::Null,
                 };
 
                 vws_handles.handles.push(VWSHandle {
                     left_offset: left,
                     right_offset: right,
                     tangent_offset: tangent,
-                    interpolation
+                    interpolation,
                 });
             }
 
             vws_outline.push(vws_handles);
         }
 
-        if vws_outline.len() > 0 {
+        if !vws_outline.is_empty() {
             return Some(vws_outline);
         }
     }
 
-    return None;
+    None
 }
 
 fn generate_vws_lib_impl(vwscontours: &Vec<VWSContour>, applied: bool) -> GlifLib {
-    if vwscontours.len() == 0 {
-        return GlifLib::None
+    if vwscontours.is_empty() {
+        return GlifLib::None;
     }
 
     let mut lib_node = plist::Dictionary::new();
@@ -477,29 +502,53 @@ fn generate_vws_lib_impl(vwscontours: &Vec<VWSContour>, applied: bool) -> GlifLi
         let mut vws_contour_node = plist::Dictionary::new();
 
         vws_contour_node.insert("applied".to_owned(), plist::Value::Boolean(applied));
-        vws_contour_node.insert("cap_start".to_owned(), plist::Value::String(vwcontour.cap_start_type.to_string()));
-        vws_contour_node.insert("cap_end".to_owned(), plist::Value::String(vwcontour.cap_end_type.to_string()));
-        vws_contour_node.insert("join".to_owned(), plist::Value::String(vwcontour.join_type.to_string()));
+        vws_contour_node.insert(
+            "cap_start".to_owned(),
+            plist::Value::String(vwcontour.cap_start_type.to_string()),
+        );
+        vws_contour_node.insert(
+            "cap_end".to_owned(),
+            plist::Value::String(vwcontour.cap_end_type.to_string()),
+        );
+        vws_contour_node.insert(
+            "join".to_owned(),
+            plist::Value::String(vwcontour.join_type.to_string()),
+        );
 
         let mut handles = vec![];
 
         for handle in &vwcontour.handles {
             let mut handle_node = plist::Dictionary::new();
 
-            handle_node.insert("left".to_owned(), plist::Value::String(handle.left_offset.to_string()));
-            handle_node.insert("right".to_owned(), plist::Value::String(handle.right_offset.to_string()));
-            handle_node.insert("tangent".to_owned(), plist::Value::String(handle.tangent_offset.to_string()));
-            handle_node.insert("interpolation".to_owned(), plist::Value::String(handle.interpolation.to_string()));
-            
+            handle_node.insert(
+                "left".to_owned(),
+                plist::Value::String(handle.left_offset.to_string()),
+            );
+            handle_node.insert(
+                "right".to_owned(),
+                plist::Value::String(handle.right_offset.to_string()),
+            );
+            handle_node.insert(
+                "tangent".to_owned(),
+                plist::Value::String(handle.tangent_offset.to_string()),
+            );
+            handle_node.insert(
+                "interpolation".to_owned(),
+                plist::Value::String(handle.interpolation.to_string()),
+            );
+
             handles.push(plist::Value::Dictionary(handle_node));
         }
         vws_contour_node.insert("handles".to_owned(), plist::Value::Array(handles));
         vws_vec.push(plist::Value::Dictionary(vws_contour_node));
     }
 
-    lib_node.insert("org.MFEK.variable_width_stroke".to_string(), plist::Value::Array(vws_vec));
+    lib_node.insert(
+        "org.MFEK.variable_width_stroke".to_string(),
+        plist::Value::Array(vws_vec),
+    );
 
-    return GlifLib::Plist(lib_node);
+    GlifLib::Plist(lib_node)
 }
 
 pub fn generate_vws_lib(vwscontours: &Vec<VWSContour>) -> GlifLib {

--- a/src/vector/conv.rs
+++ b/src/vector/conv.rs
@@ -1,6 +1,6 @@
 /// Conversion boilerplate
-use std::ops::{Add, Mul, Div, Neg, Sub};
-use std::ops::{AddAssign, MulAssign, DivAssign, SubAssign};
+use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 use std::ops::{Index, IndexMut};
 
 use super::Vector;
@@ -57,7 +57,7 @@ impl From<[f32; 2]> for Vector {
 
 impl std::cmp::PartialEq for Vector {
     fn eq(&self, other: &Vector) -> bool {
-        return self.x == other.x && self.y == other.y;
+        self.x == other.x && self.y == other.y
     }
 }
 
@@ -146,7 +146,7 @@ impl Index<usize> for Vector {
         match index {
             0 => &self.x,
             1 => &self.y,
-            _ => panic!("can only index Vector by 0 or 1")
+            _ => panic!("can only index Vector by 0 or 1"),
         }
     }
 }
@@ -156,7 +156,7 @@ impl IndexMut<usize> for Vector {
         match index {
             0 => &mut self.x,
             1 => &mut self.y,
-            _ => panic!("can only index Vector by 0 or 1")
+            _ => panic!("can only index Vector by 0 or 1"),
         }
     }
 }

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -74,7 +74,7 @@ impl Vector {
     }
 
     pub fn angle(self, v1: Vector) -> f64 {
-        return f64::atan2(v1.y, v1.x) - f64::atan2(self.y, self.x);
+        f64::atan2(v1.y, v1.x) - f64::atan2(self.y, self.x)
     }
 
     pub fn rotate(self, pivot: Vector, angle: f64) -> Vector {
@@ -87,7 +87,7 @@ impl Vector {
             y: translated_point.x * s + translated_point.y * c,
         };
 
-        return rotated_point + pivot;
+        rotated_point + pivot
     }
 }
 

--- a/src/vector/skia.rs
+++ b/src/vector/skia.rs
@@ -1,15 +1,16 @@
-#![cfg(feature="default")]
+#![cfg(feature = "default")]
 
 use super::Vector;
 
 impl Vector {
-    pub fn to_skia_point(self) -> (f32, f32)
-    {
-        return (self.x as f32, self.y as f32);
+    pub fn to_skia_point(self) -> (f32, f32) {
+        (self.x as f32, self.y as f32)
     }
 
-    pub fn from_skia_point(p: &skia_safe::Point) -> Self
-    {
-        return Vector {x: p.x as f64, y: p.y as f64 }
+    pub fn from_skia_point(p: &skia_safe::Point) -> Self {
+        Vector {
+            x: p.x as f64,
+            y: p.y as f64,
+        }
     }
 }


### PR DESCRIPTION
Changes using cargo clippy,
Now the repo is more `rusty` than before ,like
replacing 
- `return a;` with `a`
-  `vec.len()==0;` with `vec.is_empty()`
-  `a=a+1` with `a+=1`
and replacing `match` if it has only one arm with `if let` .
and many more similar changes which makes it more rusty.