### PR TITLE
Make skia optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ glifparser = { git = "https://github.com/MFEK/glifparser.rlib", branch = "master
 #glifparser = { path = "../glifparser.rlib" } # for development
 
 [features]
-default = ["skia-safe", "glifparser/skia", "glifparser/mfek"]
+default = ["glifparser/mfek"]
 strict = []
+skia = ["skia-safe", "glifparser/skia"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod arclenparameterization;
 pub mod bezier;
 pub mod consts;
 pub mod coordinate;
-#[cfg(feature = "default")]
+#[cfg(feature = "skia")]
 pub mod dash_along_path;
 pub mod evaluate;
 pub mod fit_to_points;
@@ -11,17 +11,16 @@ pub(crate) mod fixup;
 pub mod glyphbuilder;
 pub mod interpolator;
 pub mod parameterization;
-#[cfg(feature = "default")]
+#[cfg(feature = "skia")]
 pub mod pattern_along_path;
 pub mod piecewise;
 pub mod polar;
 pub mod primitive;
 pub mod rect;
-#[cfg(feature = "default")]
 pub mod variable_width_stroking;
 pub mod vector;
 
-#[cfg(feature = "default")]
+#[cfg(feature = "skia")]
 pub use {
     self::{dash_along_path::*, pattern_along_path::*, variable_width_stroking::*},
     skia_safe,

--- a/src/piecewise/mod.rs
+++ b/src/piecewise/mod.rs
@@ -1,7 +1,7 @@
-pub mod glif;
-#[cfg(feature="default")]
-mod skia;
 mod evaluate;
+pub mod glif;
+#[cfg(feature = "skia")]
+mod skia;
 
 use crate::consts::SMALL_DISTANCE;
 

--- a/src/rect/mod.rs
+++ b/src/rect/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(feature="default")]
+#[cfg(feature = "skia")]
 mod flip_if_required;
-#[cfg(feature="default")]
+#[cfg(feature = "skia")]
 pub use flip_if_required::FlipIfRequired;
 
 use super::vector::Vector;

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,4 +1,5 @@
 mod conv;
+#[cfg(feature = "skia")]
 mod skia;
 
 pub mod flo;


### PR DESCRIPTION
This, along with https://github.com/MFEK/glifparser.rlib/pull/63, makes it possible to build math.rlib and have good stuff like variable width stroking but without pulling in Skia. This is useful if you want to run variable width stroking in, oh I don't know, restricted environments like WebAssembly.

<img width="419" alt="Screenshot 2022-11-23 at 09 52 28" src="https://user-images.githubusercontent.com/106728/203516998-4c6f1d39-9aa5-4be0-a279-3588e6af28f1.png">
