### PR TITLE
Change PolarCoordinates trait impl to &mut dyn

### DIFF
--- a/src/polar.rs
+++ b/src/polar.rs
@@ -97,7 +97,7 @@ impl<PD: PointData> PolarCoordinates for Point<PD> {
     }
 }
 
-impl<PD: PointData> PolarCoordinates for dyn MFEKPointCommon<PD> {
+impl<PD: PointData> PolarCoordinates for &mut dyn MFEKPointCommon<PD> {
     fn cartesian(&self, wh: WhichHandle) -> (f32, f32) {
         let (x, y) = match wh {
             Neither => (self.x(), self.y()),


### PR DESCRIPTION
This change is required for `force_line` to work in the glyph editor. We should probably investigate why this change is even required but it seems to be an issue with rust's trait system struggling to prove the safety of the function without this.